### PR TITLE
Fix skip help text

### DIFF
--- a/src/main/kotlin/dev/arbjerg/ukulele/command/SkipCommand.kt
+++ b/src/main/kotlin/dev/arbjerg/ukulele/command/SkipCommand.kt
@@ -41,8 +41,8 @@ class SkipCommand : Command("skip", "s") {
     }
 
     override fun HelpContext.provideHelp() {
-        addUsage("[count]")
-        addDescription("Skips a number of tracks.")
+        addUsage("[index]")
+        addDescription("Skips a single track.")
         addDescription("Defaults to the first track if no number is given.")
         addUsage("<from> <to>")
         addDescription("Skips a range of tracks.")


### PR DESCRIPTION
The help text didn't match the behavior, so I updated the help text to fit the code.
The other way would be easy, but this was even easier. Either way, no missing functionality:

|                  |Type A (current) |Type B     |
|---               |---           |---           |
|Skip one first    |`skip [1]`    |`skip [1]`    |
|**Skip one later**|`skip <i>`    |`skip <i> <i>` (not obvious IMO)|
|**Skip first n**  |`skip 1 <n>`  |`skip <n>`    |
|Skip range        |`skip <a> <b>`|`skip <a> <b>`|