### PR TITLE
Move to maintained LavaPlayer fork

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,8 +24,6 @@ dependencies {
     // The snapshot version published in jitpack has this, so it is utilized for now.
     // Eventually, a full upgrade to JDA 5.x will be necessary.
     implementation("com.github.DV8FromTheWorld:JDA:legacy~v4-SNAPSHOT")
-    //implementation("com.sedmelluq:lavaplayer:1.3.78")
-    //implementation("com.github.walkyst.lavaplayer-fork:lavaplayer:1.4.0")
     implementation("dev.arbjerg:lavaplayer:1.5.0")
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,8 @@ dependencies {
     // Eventually, a full upgrade to JDA 5.x will be necessary.
     implementation("com.github.DV8FromTheWorld:JDA:legacy~v4-SNAPSHOT")
     //implementation("com.sedmelluq:lavaplayer:1.3.78")
-    implementation("com.github.walkyst.lavaplayer-fork:lavaplayer:1.4.0")
+    //implementation("com.github.walkyst.lavaplayer-fork:lavaplayer:1.4.0")
+    implementation("dev.arbjerg:lavaplayer:1.5.0")
     implementation("org.springframework.boot:spring-boot-starter-data-r2dbc")
 
     runtimeOnly("com.h2database:h2")


### PR DESCRIPTION
I've been seeing frequent 403s from LavaPlayer on my instance, something not unnoticed by other users of the library: https://github.com/Walkyst/lavaplayer-fork/issues/108 This may also be the cause of #67.

I tried updating to a nearby version of the recommended fork, and aside from some angry tracebacks during the build (probably shouldn't have built the new version while the old version was still running), the build succeeded and the issue seems to be resolved after a couple hours of testing.